### PR TITLE
Add link to readme for script-based system testing approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,18 @@
 
 [![](https://github.com/CISC-CMPE-327/CI-Python/workflows/Python%20application/badge.svg)](https://github.com/CISC-CMPE-327/CI-Python/actions)
 
-Python CI template for GitHub Actions
+### Python CI template for GitHub Actions
+
+<hr>
+
+If you would like to use `pytest` for system testing, please skip the rest of this paragraph.</br>
+Otherwise, if you are having problems setting up pytest/creating test cases/getting everything to work, you may want to consider using an alternate script-based approach. The repositoty linked below shows how to do this:
+
+https://github.com/vacer25/CMPE-327/
+
+The rest of this document refers to the pytest system testing approach.
+
+<hr>
 
 Folder structure:
 ```


### PR DESCRIPTION
## Proposed Change

- Add short paragraph and link to my repository at the top of readme for system testing using a script-based system testing approach instead of pytest for anyone who may want to investigate this option.

## Why are you requesting this change?

- Noticed a few groups had issues getting the pytest framework to work at all.
- The script-based approach is somewhat more easily customizable IMO.